### PR TITLE
Minor updates to README for location of ArgoCD config and Arlon repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.17.9 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= 0.1.0
 REPO_SERVER ?= ghcr.io
-REPO_NAME ?= platform9-incubator
+REPO_NAME ?= platform9
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO_SERVER)/$(REPO_NAME)/arlon/controller:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ You can use any Kubernetes cluster that you have admin access to. Ensure:
 - Follow steps 1-4 of the [ArgoCD installation guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install ArgoCD onto your management cluster.
 After this step, you should be logged in as `admin` and a config file was created at `${HOME}/.config/argocd/config`
 - Create your workspace repository in your git provider if necessary, then register it.
-  Example: `argocd repo add https://github.com/myname/arlon --username myname --password secret`.
-  Note: type `argocd repo add --help` to see all available options.
+  Example: `argocd repo add https://github.com/myname/arlon_workspace --username myname --password secret`.
+   -  Note: type `argocd repo add --help` to see all available options.
+   -  For Arlon developers, this is not your fork of the Arlon source code repository, 
+       but a separate git repo where some artefacts like profiles created by Arlon will be stored. 
 - Highly recommended: [configure a webhook](https://argo-cd.readthedocs.io/en/stable/operator-manual/webhook/)
   to immediately notify ArgoCD of changes to the repo. This will be especially useful
   during the tutorial. Without a webhook, repo changes may take up to 3 minutes

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can use any Kubernetes cluster that you have admin access to. Ensure:
 ## ArgoCD
 
 - Follow steps 1-4 of the [ArgoCD installation guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install ArgoCD onto your management cluster.
-After this step, you should be logged in as `admin` and a config file was created at `${HOME}/.argocd/config`
+After this step, you should be logged in as `admin` and a config file was created at `${HOME}/.config/argocd/config`
 - Create your workspace repository in your git provider if necessary, then register it.
   Example: `argocd repo add https://github.com/myname/arlon --username myname --password secret`.
   Note: type `argocd repo add --help` to see all available options.
@@ -186,7 +186,7 @@ kind: ConfigMap
 [...]
 ```
 - Generate an account token: `argocd account generate-token --account arlon`
-- Make a temporary copy of the config file: `cp ${HOME}/.argocd/config /tmp` then
+- Make a temporary copy of the config file: `cp ${HOME}/.config/argocd/config /tmp/argocd_config` then
   edit it to replace the value of `auth-token` with the token from
   the previous step. Save changes. This file will be used to configure the Arlon
   controller's ArgoCD credentials during the next steps.
@@ -194,7 +194,7 @@ kind: ConfigMap
 ## Arlon controller
 - Create the arlon namespace: `kubectl create ns arlon`
 - Create the ArgoCD credentials secret from the temporary config file:
-  `kubectl -n arlon create secret generic argocd-creds --from-file /tmp/config`
+  `kubectl -n arlon create secret generic argocd-creds --from-file /tmp/argocd_config`
 - Delete the temporary config file
 - Clone the arlon git repo and cd to its top directory
 - Create the `clusterregistrations` CRD: `kubectl apply -f config/crd/bases/arlon.io_clusterregistrations.yaml`


### PR DESCRIPTION
* to correct the location of the ArgoCD config file and its temporary copy
* to change the name/ location of user's Arlon workspace repo to distinguish it from Arlon source code