### PR TITLE
Fix for issue #30 : Fix make test on Apple Silicon by setting CPU arch to amd64 for Darwin/ MacOS,  relying on rosetta 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; export GOARCH=amd64; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
Fix for [issue #30](https://github.com/platform9/arlon/issues/30) : Fix docker-build for Apple CPU by setting CPU arch to amd64 for Darwin/ MacOS,  relying on rosetta 2

The script `setup-envtest.sh` tries to download the envtest binary based on the GOARCH (ARM for Apple CPU or AMD for x86) and GOOS (OS : Linux / Darwin). However, there are no darwin-arm64 binaries available at [https://storage.googleapis.com/kubebuilder-tools/](https://storage.googleapis.com/kubebuilder-tools/), causing this script to fail. As a quick fix, this one-liner change forces the GOARCH to be 'amd64' (even when it is detected as 'arm64') in order to download a valid binary, relying on rosetta to run that binary on the Apple (m1/ m2) Silicon.

