### PR TITLE
kubebuilder project changes: domain, group, and repo location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.1.0
+VERSION ?= 0.2.0
 REPO_SERVER ?= ghcr.io
 REPO_NAME ?= platform9
 # Image URL to use all building/pushing image targets

--- a/PROJECT
+++ b/PROJECT
@@ -1,16 +1,16 @@
-domain: arlo.org
+domain: arlon.io
 layout:
 - go.kubebuilder.io/v3
-projectName: arlo4
-repo: arlo.org/arlo
+projectName: arlon
+repo: github.com/platform9/arlon
 resources:
 - api:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: arlo.org
-  group: arlo
+  domain: arlon.io
+  group: core
   kind: ClusterRegistration
-  path: arlo.org/arlo/api/v1
+  path: github.com/platform9/arlon/api/v1
   version: v1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ kind: ConfigMap
   `kubectl -n arlon create secret generic argocd-creds --from-file /tmp/argocd_config`
 - Delete the temporary config file
 - Clone the arlon git repo and cd to its top directory
-- Create the `clusterregistrations` CRD: `kubectl apply -f config/crd/bases/arlon.io_clusterregistrations.yaml`
+- Create the `clusterregistrations` CRD: `kubectl apply -f config/crd/bases/core.arlon.io_clusterregistrations.yaml`
 - Deploy the controller: `kubectl apply -f deploy/manifests/`
 - Ensure the controller eventually enters the Running state: `watch kubectl -n arlon get pod`
 

--- a/api/v1/clusterregistration_types.go
+++ b/api/v1/clusterregistration_types.go
@@ -64,7 +64,7 @@ type ClusterRegistrationList struct {
 }
 
 const (
-	ClusterRegistrationFinalizer = "clusterregistration.arlon.io"
+	ClusterRegistrationFinalizer = "clusterregistration.core.arlon.io"
 )
 
 func init() {

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1 contains API Schema definitions for the arlo v1 API group
 //+kubebuilder:object:generate=true
-//+groupName=arlon.io
+//+groupName=core.arlon.io
 package v1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "arlon.io", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "core.arlon.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/bundle/create.go
+++ b/cmd/bundle/create.go
@@ -1,8 +1,8 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/bundle"
 	"fmt"
+	"github.com/platform9/arlon/pkg/bundle"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/bundle/delete.go
+++ b/cmd/bundle/delete.go
@@ -1,8 +1,8 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/bundle"
 	"fmt"
+	"github.com/platform9/arlon/pkg/bundle"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"

--- a/cmd/bundle/list.go
+++ b/cmd/bundle/list.go
@@ -1,9 +1,9 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
+	"github.com/platform9/arlon/pkg/common"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/cmd/bundle/update.go
+++ b/cmd/bundle/update.go
@@ -1,8 +1,8 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/bundle"
 	"fmt"
+	"github.com/platform9/arlon/pkg/bundle"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/cluster/deploy.go
+++ b/cmd/cluster/deploy.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/argocd"
-	"arlon.io/arlon/pkg/cluster"
 	_ "embed"
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/platform9/arlon/pkg/argocd"
+	"github.com/platform9/arlon/pkg/cluster"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -1,14 +1,14 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/argocd"
-	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
 	apppkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/platform9/arlon/pkg/argocd"
+	"github.com/platform9/arlon/pkg/common"
 	"github.com/spf13/cobra"
 	"os"
 	"text/tabwriter"

--- a/cmd/cluster/update.go
+++ b/cmd/cluster/update.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/argocd"
-	"arlon.io/arlon/pkg/cluster"
 	_ "embed"
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/platform9/arlon/pkg/argocd"
+	"github.com/platform9/arlon/pkg/cluster"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"

--- a/cmd/clusterspec/create.go
+++ b/cmd/clusterspec/create.go
@@ -1,8 +1,8 @@
 package clusterspec
 
 import (
-	cspec "arlon.io/arlon/pkg/clusterspec"
 	"fmt"
+	cspec "github.com/platform9/arlon/pkg/clusterspec"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/clusterspec/delete.go
+++ b/cmd/clusterspec/delete.go
@@ -1,8 +1,8 @@
 package clusterspec
 
 import (
-	"arlon.io/arlon/pkg/clusterspec"
 	"fmt"
+	"github.com/platform9/arlon/pkg/clusterspec"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"

--- a/cmd/clusterspec/list.go
+++ b/cmd/clusterspec/list.go
@@ -1,10 +1,10 @@
 package clusterspec
 
 import (
-	"arlon.io/arlon/pkg/clusterspec"
 	"context"
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/util/cli"
+	"github.com/platform9/arlon/pkg/clusterspec"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/cmd/clusterspec/update.go
+++ b/cmd/clusterspec/update.go
@@ -1,8 +1,8 @@
 package clusterspec
 
 import (
-	cspec "arlon.io/arlon/pkg/clusterspec"
 	"fmt"
+	cspec "github.com/platform9/arlon/pkg/clusterspec"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"arlon.io/arlon/pkg/controller"
+	"github.com/platform9/arlon/pkg/controller"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list_clusters/list_clusters.go
+++ b/cmd/list_clusters/list_clusters.go
@@ -1,13 +1,13 @@
 package list_clusters
 
 import (
-	"arlon.io/arlon/pkg/argocd"
 	"context"
 	"fmt"
 	clusterpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/errors"
 	"github.com/argoproj/argo-cd/v2/util/io"
+	"github.com/platform9/arlon/pkg/argocd"
 	"github.com/spf13/cobra"
 	"os"
 	"text/tabwriter"

--- a/cmd/profile/create.go
+++ b/cmd/profile/create.go
@@ -1,8 +1,8 @@
 package profile
 
 import (
-	"arlon.io/arlon/pkg/profile"
 	"fmt"
+	"github.com/platform9/arlon/pkg/profile"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/profile/delete.go
+++ b/cmd/profile/delete.go
@@ -1,8 +1,8 @@
 package profile
 
 import (
-	"arlon.io/arlon/pkg/profile"
 	"fmt"
+	"github.com/platform9/arlon/pkg/profile"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"

--- a/cmd/profile/update.go
+++ b/cmd/profile/update.go
@@ -1,8 +1,8 @@
 package profile
 
 import (
-	"arlon.io/arlon/pkg/profile"
 	"fmt"
+	"github.com/platform9/arlon/pkg/profile"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/config/crd/bases/core.arlon.io_clusterregistrations.yaml
+++ b/config/crd/bases/core.arlon.io_clusterregistrations.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: clusterregistrations.arlon.io
+  name: clusterregistrations.core.arlon.io
 spec:
-  group: arlon.io
+  group: core.arlon.io
   names:
     kind: ClusterRegistration
     listKind: ClusterRegistrationList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/arlon.io_clusterregistrations.yaml
+- bases/core.arlon.io_clusterregistrations.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_clusterregistrations.yaml
+++ b/config/crd/patches/cainjection_in_clusterregistrations.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: clusterregistrations.arlon.io
+  name: clusterregistrations.core.arlon.io

--- a/config/crd/patches/webhook_in_clusterregistrations.yaml
+++ b/config/crd/patches/webhook_in_clusterregistrations.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterregistrations.arlon.io
+  name: clusterregistrations.core.arlon.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -8,4 +8,4 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: true
-  resourceName: d4242dee.arlon.io
+  resourceName: d4242dee.core.arlon.io

--- a/config/rbac/clusterregistration_editor_role.yaml
+++ b/config/rbac/clusterregistration_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clusterregistration-editor-role
 rules:
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations/status
   verbs:

--- a/config/rbac/clusterregistration_viewer_role.yaml
+++ b/config/rbac/clusterregistration_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clusterregistration-viewer-role
 rules:
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations
   verbs:
@@ -19,13 +19,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations/finalizers
   verbs:
   - update
 - apiGroups:
-  - arlon.io
+  - core.arlon.io
   resources:
   - clusterregistrations/status
   verbs:

--- a/config/samples/arlon_v1_clusterregistration.yaml
+++ b/config/samples/arlon_v1_clusterregistration.yaml
@@ -1,4 +1,4 @@
-apiVersion: arlon.io/v1
+apiVersion: core.arlon.io/v1
 kind: ClusterRegistration
 metadata:
   name: clusterregistration-sample

--- a/config/samples/capi-eks-example/bootstrap/clusterregistration.yaml
+++ b/config/samples/capi-eks-example/bootstrap/clusterregistration.yaml
@@ -1,4 +1,4 @@
-apiVersion: arlon.io/v1
+apiVersion: core.arlon.io/v1
 kind: ClusterRegistration
 metadata:
   name: capi-eks-quickstart

--- a/config/samples/capi-example/bootstrap/clusterregistration.yaml
+++ b/config/samples/capi-example/bootstrap/clusterregistration.yaml
@@ -1,4 +1,4 @@
-apiVersion: arlon.io/v1
+apiVersion: core.arlon.io/v1
 kind: ClusterRegistration
 metadata:
   name: capi-quickstart

--- a/controllers/clusterregistration_controller.go
+++ b/controllers/clusterregistration_controller.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	arlonv1 "arlon.io/arlon/api/v1"
 	"context"
 	"fmt"
 	cmdutil "github.com/argoproj/argo-cd/v2/cmd/util"
@@ -27,6 +26,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/clusterauth"
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/go-logr/logr"
+	arlonv1 "github.com/platform9/arlon/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,9 +48,9 @@ type ClusterRegistrationReconciler struct {
 	ArgocdClient apiclient.Client
 }
 
-//+kubebuilder:rbac:groups=arlon.io,resources=clusterregistrations,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=arlon.io,resources=clusterregistrations/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=arlon.io,resources=clusterregistrations/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core.arlon.io,resources=clusterregistrations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core.arlon.io,resources=clusterregistrations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=core.arlon.io,resources=clusterregistrations/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "github.com/platform9/arlon/api/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,8 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	arlonv1 "arlon.io/arlon/api/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -62,7 +61,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = arlonv1.AddToScheme(scheme.Scheme)
+	err = corev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/deploy/manifests/deploy.yaml
+++ b/deploy/manifests/deploy.yaml
@@ -25,7 +25,7 @@ spec:
         - controller
         - --argocd-config-path
         - /.argocd/config
-        image: ghcr.io/platform9-incubator/arlon/controller:0.1.0
+        image: ghcr.io/platform9/arlon/controller:0.2.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/deploy/manifests/rbac.yaml
+++ b/deploy/manifests/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   # "namespace" omitted since ClusterRoles are not namespaced
   name: clusterregistration-updater
 rules:
-  - apiGroups: ["arlon.io"]
+  - apiGroups: ["core.arlon.io"]
     #
     # at the HTTP level, the name of the resource for accessing Secret
     # objects is "secrets"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module arlon.io/arlon
+module github.com/platform9/arlon
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -17,15 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"arlon.io/arlon/cmd/bundle"
-	"arlon.io/arlon/cmd/cluster"
-	"arlon.io/arlon/cmd/clusterspec"
-	"arlon.io/arlon/cmd/controller"
-	"arlon.io/arlon/cmd/list_clusters"
-	"arlon.io/arlon/cmd/profile"
 	"flag"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/platform9/arlon/cmd/bundle"
+	"github.com/platform9/arlon/cmd/cluster"
+	"github.com/platform9/arlon/cmd/clusterspec"
+	"github.com/platform9/arlon/cmd/controller"
+	"github.com/platform9/arlon/cmd/list_clusters"
+	"github.com/platform9/arlon/cmd/profile"
+	"github.com/spf13/cobra"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -1,9 +1,9 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
+	"github.com/platform9/arlon/pkg/common"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1types "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/pkg/bundle/create.go
+++ b/pkg/bundle/create.go
@@ -1,9 +1,9 @@
 package bundle
 
 import (
-	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
+	"github.com/platform9/arlon/pkg/common"
 	v1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/cluster/git.go
+++ b/pkg/cluster/git.go
@@ -1,15 +1,15 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/argocd"
-	"arlon.io/arlon/pkg/bundle"
-	"arlon.io/arlon/pkg/gitutils"
-	"arlon.io/arlon/pkg/log"
 	"bytes"
 	"context"
 	"embed"
 	"fmt"
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/platform9/arlon/pkg/argocd"
+	"github.com/platform9/arlon/pkg/bundle"
+	"github.com/platform9/arlon/pkg/gitutils"
+	"github.com/platform9/arlon/pkg/log"
 	"io"
 	"io/fs"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/cluster/manifests/templates/clusterregistration.yaml
+++ b/pkg/cluster/manifests/templates/clusterregistration.yaml
@@ -1,4 +1,4 @@
-apiVersion: arlon.io/v1
+apiVersion: core.arlon.io/v1
 kind: ClusterRegistration
 metadata:
   name: {{ .Values.global.clusterName }}

--- a/pkg/cluster/root_app.go
+++ b/pkg/cluster/root_app.go
@@ -1,11 +1,11 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/clusterspec"
-	"arlon.io/arlon/pkg/common"
 	"fmt"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/platform9/arlon/pkg/clusterspec"
+	"github.com/platform9/arlon/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"arlon.io/arlon/pkg/clusterspec"
-	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
 	argoapp "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/platform9/arlon/pkg/clusterspec"
+	"github.com/platform9/arlon/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
-	arlonv1 "arlon.io/arlon/api/v1"
-	"arlon.io/arlon/controllers"
-	"arlon.io/arlon/pkg/argocd"
+	arlonv1 "github.com/platform9/arlon/api/v1"
+	"github.com/platform9/arlon/controllers"
+	"github.com/platform9/arlon/pkg/argocd"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/profile/git.go
+++ b/pkg/profile/git.go
@@ -1,14 +1,14 @@
 package profile
 
 import (
-	"arlon.io/arlon/pkg/argocd"
-	"arlon.io/arlon/pkg/bundle"
-	"arlon.io/arlon/pkg/cluster"
-	"arlon.io/arlon/pkg/gitutils"
-	"arlon.io/arlon/pkg/log"
 	"embed"
 	"fmt"
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/platform9/arlon/pkg/argocd"
+	"github.com/platform9/arlon/pkg/bundle"
+	"github.com/platform9/arlon/pkg/cluster"
+	"github.com/platform9/arlon/pkg/gitutils"
+	"github.com/platform9/arlon/pkg/log"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"path"


### PR DESCRIPTION
This is an API breaking change, necessary to make kubebuilder happy.
- Domain was changed to `arlon.io`
- Group name is now `core`
- Repo is now `github.com/platform9/arlon`
- Controller image version bumped to 0.2.0, and repo location updated (platform9-incubator --> platform9)

After this change, existing installations will need to install a new CRD and redeploy the arlon controller. Also, the image at ghcr.io/platform9/arlon/arlon-controller is still private and cannot be pulled by Kubernetes. I asked devops team to make it public.
