### PR TITLE
Fixes issue #35 : Include manifests and config objects (CRDs etc) in  the Arlon container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,16 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o arlon main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+# Note that distroless images do not contain shell
+# Use busybox to debug with shell and tools like ls, cat
+#FROM busybox:1.35.0-uclibc as busybox
 WORKDIR /
 COPY --from=builder /workspace/arlon .
+COPY deploy/manifests deploy/manifests
+COPY config config
 USER 65532:65532
 
 ENTRYPOINT ["/arlon"]
+
+# Uncomment when debugging with busybox image : to debug with shell and tools like ls, cat
+#ENTRYPOINT [ "/bin/sh" ]


### PR DESCRIPTION
Change OSS Arlon Controller to Include manifests and config objects (CRDs etc) in the Arlon container image so that these objects will be available in the container image built. When this container image is deployed in the management cluster, these objects can be applied using kubectl instead of manually running the installation steps for controller in [GitHub - platform9/arlon: A kubernetes cluster lifecycle management and configuration tool](https://github.com/platform9/arlon#arlon-controller)  to deploy the controller and create the CRDs for cluster registration etc.